### PR TITLE
Victoria Week 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 *.pdf
 *.phpproj
 dbconfig.php
+file_path.php
 files/*
 phpunit/.phpunit.result.cache

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -340,8 +340,6 @@ function generateGrid() {
     // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
     title = $('#title').val('');
     description = $('#description').val('');
-    dateStart = $('#dateStart').val('');
-    dateEnd = $('#dateEnd').val('');
     location = $('#location').val('');
     });
 

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -338,25 +338,32 @@ function generateGrid() {
             }
         })
     // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
+    // Don't try to use this for the dates or after submitting, no matter where
+    // you click on the calendar it will just say mm/dd/yyyy until you refresh
     title = $('#title').val('');
     description = $('#description').val('');
     location = $('#location').val('');
     });
 
     // GIVES FUNCTIONALITY TO X BUTTON. Now actually clears form when clicked
+    // Also does not work with dates
     $(document).on('click', '.ui-dialog-titlebar-close', function(){
         var title = $('#title').val();
         var description = $('#description').val();
-        var dateStart = $('#dateStart').val();
-        var dateEnd = $('#dateEnd').val();
-        var creatorID = $('#creatorID').val();    
         var location = $('#location').val();
         title = $('#title').val('');
         description = $('#description').val('');
         location = $('#location').val('');
-        dateStart = $('#dateStart').val();
-        dateEnd = $('#dateEnd').val();
     });
+
+    $("body > *").not("body > button").click(function(e) {
+        console.log(e.target.id);
+       if(e.target.id=='dialog-form'){
+               return false;
+        }
+        $('div#dialog-form').hide();
+
+   });
 
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 
     $('#deletebtn').on('click',function(e) {

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -354,8 +354,8 @@ function generateGrid() {
         title = $('#title').val('');
         description = $('#description').val('');
         location = $('#location').val('');
-        creatorID = $('#creatorID').val('');    
-        location = $('#location').val('');
+        dateStart = $('#dateStart').val();
+        dateEnd = $('#dateEnd').val();
     });
 
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -337,6 +337,7 @@ function generateGrid() {
                 console.log(error);
             }
         })
+    title = $('#title').val('');
     });
 
     // CLEAR FORMS AFTER SUBMIT

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -356,12 +356,12 @@ function generateGrid() {
         if (e.className && e.className.indexOf('ui-dialog-titlebar-close') != -1) {
             //if the element has a class name, and that is 'someclass' then...
             e.preventDefault();
-        var title = $('#title').val('');
-        var description = $('#description').val('');
-        var dateStart = $('#dateStart').val('');
-        var dateEnd = $('#dateEnd').val('');
-        var creatorID = $('#creatorID').val('');    
-        var location = $('#location').val('');
+        var title = $('#title').val();
+        var description = $('#description').val();
+        var dateStart = $('#dateStart').val();
+        var dateEnd = $('#dateEnd').val();
+        var creatorID = $('#creatorID').val();    
+        var location = $('#location').val();
         }
     }
 

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -340,16 +340,7 @@ function generateGrid() {
     });
 
     // CLEAR FORMS AFTER SUBMIT
-    function submitForm() {
-        // Get the first form with the name
-        // Usually the form name is not repeated
-        // but duplicate names are possible in HTML
-        // Therefore to work around the issue, enforce the correct index
-        var frm = document.getElementsByName('calcreate')[0];
-        frm.submit(); // Submit the form
-        frm.reset();  // Reset all form data
-        return false; // Prevent page refresh
-     }
+
 
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 
     $('#deletebtn').on('click',function(e) {

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -345,17 +345,9 @@ function generateGrid() {
 
     // CODE SPECIALLY TO CLEAR FORM IN CREATE EVENT AFTER SUBMITTING
 
-    $('#button.ui-dialog-titlebar-close').click(function() {
-        var title = $('#title').val();
-        var description = $('#description').val();
-        var dateStart = $('#dateStart').val();
-        var dateEnd = $('#dateEnd').val();
-        var creatorID = $('#creatorID').val();    
-        var location = $('#location').val();
-        title = $('#title').val('');
-        description = $('#description').val('');
-        location = $('#location').val('');
-      });
+    $('.ui-dialog-titlebar-close').click(function(){
+        $('#calcreate')[0].reset();
+    });
 
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 
     $('#deletebtn').on('click',function(e) {

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -339,6 +339,9 @@ function generateGrid() {
         })
     });
 
+    // CLEAR FORMS AFTER SUBMIT
+    document.getElementById("calcreate").reset();
+
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 
     $('#deletebtn').on('click',function(e) {
         var id = $("#edit-delete").data('id');

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -343,8 +343,34 @@ function generateGrid() {
     location = $('#location').val('');
     });
 
-    // CLEAR FORMS AFTER SUBMIT
+    // CODE SPECIALLY TO CLEAR FORM IN CREATE EVENT AFTER SUBMITTING
 
+    document.body.onclick = function(e) {   //when the document body is clicked
+        if (window.event) {
+            e = event.srcElement;           //assign the element clicked to e (IE 6-8)
+        }
+        else {
+            e = e.target;                   //assign the element clicked to e
+        }
+    
+        if (e.className && e.className.indexOf('ui-dialog-titlebar-close') != -1) {
+            //if the element has a class name, and that is 'someclass' then...
+            e.preventDefault();
+        var title = $('#title').val('');
+        var description = $('#description').val('');
+        var dateStart = $('#dateStart').val('');
+        var dateEnd = $('#dateEnd').val('');
+        var creatorID = $('#creatorID').val('');    
+        var location = $('#location').val('');
+        }
+    }
+
+     // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
+     title = $('#title').val('');
+     description = $('#description').val('');
+     location = $('#location').val('');
+     dateStart = $('#dateStart').val('');
+     dateEnd = $('#dateEnd').val('');
 
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 
     $('#deletebtn').on('click',function(e) {

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -345,7 +345,14 @@ function generateGrid() {
 
     // CODE SPECIALLY TO CLEAR FORM IN CREATE EVENT AFTER SUBMITTING
 
-    
+    $('.ui-dialog-titlebar-close').click(function() {
+        var title = $('#title').val();
+        var description = $('#description').val();
+        var dateStart = $('#dateStart').val();
+        var dateEnd = $('#dateEnd').val();
+        var creatorID = $('#creatorID').val('');    
+        var location = $('#location').val('');
+      });
 
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 
     $('#deletebtn').on('click',function(e) {

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -350,8 +350,11 @@ function generateGrid() {
         var description = $('#description').val();
         var dateStart = $('#dateStart').val();
         var dateEnd = $('#dateEnd').val();
-        var creatorID = $('#creatorID').val('');    
-        var location = $('#location').val('');
+        var creatorID = $('#creatorID').val();    
+        var location = $('#location').val();
+        title = $('#title').val('');
+        description = $('#description').val('');
+        location = $('#location').val('');
       });
 
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -345,8 +345,16 @@ function generateGrid() {
 
     // CODE SPECIALLY TO CLEAR FORM IN CREATE EVENT AFTER SUBMITTING
 
-    $('.ui-dialog-titlebar-close').click(function(){
-        $('#calcreate').get(0).reset();
+    $(document).on('click', '.ui-dialog-titlebar-close', function(){
+        var title = $('#title').val();
+        var description = $('#description').val();
+        var dateStart = $('#dateStart').val();
+        var dateEnd = $('#dateEnd').val();
+        var creatorID = $('#creatorID').val();    
+        var location = $('#location').val();
+        title = $('#title').val('');
+        description = $('#description').val('');
+        location = $('#location').val('');
     });
 
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -365,6 +365,14 @@ function generateGrid() {
 
    });
 
+   $("body > *").not("body > button").click(function(e) {
+        console.log(e.target.id);
+        if(e.target.id=='ui-id-1'){
+                return false;
+            }
+            $('div#ui-id-1').hide();
+    });
+
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 
     $('#deletebtn').on('click',function(e) {
         var id = $("#edit-delete").data('id');

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -356,23 +356,6 @@ function generateGrid() {
         location = $('#location').val('');
     });
 
-    $("body > *").not("body > button").click(function(e) {
-        console.log(e.target.id);
-       if(e.target.id=='dialog-form'){
-               return false;
-        }
-        $('div#dialog-form').hide();
-
-   });
-
-   $("body > *").not("body > button").click(function(e) {
-        console.log(e.target.id);
-        if(e.target.id=='ui-id-1'){
-                return false;
-            }
-            $('div#ui-id-1').hide();
-    });
-
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 
     $('#deletebtn').on('click',function(e) {
         var id = $("#edit-delete").data('id');

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -337,7 +337,12 @@ function generateGrid() {
                 console.log(error);
             }
         })
+    // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
     title = $('#title').val('');
+    description = $('#description').val('');
+    dateStart = $('#dateStart').val('');
+    dateEnd = $('#dateEnd').val('');
+    location = $('#location').val('');
     });
 
     // CLEAR FORMS AFTER SUBMIT

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -336,6 +336,7 @@ function generateGrid() {
             error: function(error) {
                 console.log(error);
             }
+            $("#dialog-form")[0].reset();
         })
     });
 

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -336,7 +336,6 @@ function generateGrid() {
             error: function(error) {
                 console.log(error);
             }
-            $("#dialog-form")[0].reset();
         })
     });
 

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -343,8 +343,7 @@ function generateGrid() {
     location = $('#location').val('');
     });
 
-    // CODE SPECIALLY TO CLEAR FORM IN CREATE EVENT AFTER SUBMITTING
-
+    // GIVES FUNCTIONALITY TO X BUTTON. Now actually clears form when clicked
     $(document).on('click', '.ui-dialog-titlebar-close', function(){
         var title = $('#title').val();
         var description = $('#description').val();
@@ -354,6 +353,8 @@ function generateGrid() {
         var location = $('#location').val();
         title = $('#title').val('');
         description = $('#description').val('');
+        location = $('#location').val('');
+        creatorID = $('#creatorID').val('');    
         location = $('#location').val('');
     });
 

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -345,12 +345,7 @@ function generateGrid() {
 
     // CODE SPECIALLY TO CLEAR FORM IN CREATE EVENT AFTER SUBMITTING
 
-     // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
-     title = $('#title').val('');
-     description = $('#description').val('');
-     location = $('#location').val('');
-     dateStart = $('#dateStart').val('');
-     dateEnd = $('#dateEnd').val('');
+    
 
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 
     $('#deletebtn').on('click',function(e) {

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -345,8 +345,6 @@ function generateGrid() {
 
     // CODE SPECIALLY TO CLEAR FORM IN CREATE EVENT AFTER SUBMITTING
 
-
-
      // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
      title = $('#title').val('');
      description = $('#description').val('');

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -345,7 +345,7 @@ function generateGrid() {
 
     // CODE SPECIALLY TO CLEAR FORM IN CREATE EVENT AFTER SUBMITTING
 
-    $('.ui-dialog-titlebar-close').click(function() {
+    $('#button.ui-dialog-titlebar-close').click(function() {
         var title = $('#title').val();
         var description = $('#description').val();
         var dateStart = $('#dateStart').val();

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -340,7 +340,16 @@ function generateGrid() {
     });
 
     // CLEAR FORMS AFTER SUBMIT
-    document.getElementById("calcreate").reset();
+    function submitForm() {
+        // Get the first form with the name
+        // Usually the form name is not repeated
+        // but duplicate names are possible in HTML
+        // Therefore to work around the issue, enforce the correct index
+        var frm = document.getElementsByName('calcreate')[0];
+        frm.submit(); // Submit the form
+        frm.reset();  // Reset all form data
+        return false; // Prevent page refresh
+     }
 
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 
     $('#deletebtn').on('click',function(e) {

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -346,7 +346,7 @@ function generateGrid() {
     // CODE SPECIALLY TO CLEAR FORM IN CREATE EVENT AFTER SUBMITTING
 
     $('.ui-dialog-titlebar-close').click(function(){
-        $('#calcreate')[0].reset();
+        $('#calcreate').get(0).reset();
     });
 
     //BUTTON TO TRIGGER DELETE - THIS GETS FORM DATA FOR EDIT-FORM 

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -345,25 +345,7 @@ function generateGrid() {
 
     // CODE SPECIALLY TO CLEAR FORM IN CREATE EVENT AFTER SUBMITTING
 
-    document.body.onclick = function(e) {   //when the document body is clicked
-        if (window.event) {
-            e = event.srcElement;           //assign the element clicked to e (IE 6-8)
-        }
-        else {
-            e = e.target;                   //assign the element clicked to e
-        }
-    
-        if (e.className && e.className.indexOf('ui-dialog-titlebar-close') != -1) {
-            //if the element has a class name, and that is 'someclass' then...
-            e.preventDefault();
-        var title = $('#title').val();
-        var description = $('#description').val();
-        var dateStart = $('#dateStart').val();
-        var dateEnd = $('#dateEnd').val();
-        var creatorID = $('#creatorID').val();    
-        var location = $('#location').val();
-        }
-    }
+
 
      // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
      title = $('#title').val('');

--- a/assets/js/manage_events_main.js
+++ b/assets/js/manage_events_main.js
@@ -60,10 +60,28 @@ function createdEventHist() {
                 console.log(error);
             }
         })
+    // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
+    title = $('#title').val('');
+    description = $('#description').val('');
+	location = $('#location').val('');
+	dateStart = $('#dateStart').val('');
+	dateEnd = $('#dateEnd').val('');
     });
 
     calendar.render();
 }
+
+    // GIVES FUNCTIONALITY TO X BUTTON. Now actually clears form when clicked
+    $(document).on('click', '.ui-dialog-titlebar-close', function(){
+        var title = $('#title').val();
+        var description = $('#description').val();
+        var location = $('#location').val();
+        title = $('#title').val('');
+        description = $('#description').val('');
+        location = $('#location').val('');
+        dateStart = $('#dateStart').val('');
+        dateEnd = $('#dateEnd').val('');
+    });
 
 /*
 function eventInfo(){

--- a/assets/js/manage_events_main.js
+++ b/assets/js/manage_events_main.js
@@ -35,8 +35,8 @@ function createdEventHist() {
 		$( "#dialog-form" ).dialog();
 	});
 
-     //BUTTON TO CREATE NEW EVENT - SUBMIT BUTTON IN CREATE_EVENT.PHP
-     $('#signupbtn').on('click',function(e){
+    //BUTTON TO CREATE NEW EVENT - SUBMIT BUTTON IN CREATE_EVENT.PHP
+    $('#signupbtn').on('click',function(e){
         e.preventDefault();
         var title = $('#title').val();
         var description = $('#description').val();
@@ -44,6 +44,7 @@ function createdEventHist() {
         var dateEnd = $('#dateEnd').val();
         var creatorID = $('#creatorID').val();    
         var location = $('#location').val();
+        //var RSVPLim = $('#RSVPLim').val();
         $.ajax({
             url:"../Schedule-it/database/event/insert.php",
             type:"POST",
@@ -59,28 +60,10 @@ function createdEventHist() {
                 console.log(error);
             }
         })
-    // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
-    title = $('#title').val('');
-    description = $('#description').val('');
-	location = $('#location').val('');
-	dateStart = $('#dateStart').val('');
-	dateEnd = $('#dateEnd').val('');
     });
 
     calendar.render();
 }
-
-    // GIVES FUNCTIONALITY TO X BUTTON. Now actually clears form when clicked
-    $(document).on('click', '.ui-dialog-titlebar-close', function(){
-        var title = $('#title').val();
-        var description = $('#description').val();
-        var location = $('#location').val();
-        title = $('#title').val('');
-        description = $('#description').val('');
-		location = $('#location').val('');
-		dateStart = $('#dateStart').val('');
-		dateEnd = $('#dateEnd').val('');
-    });
 
 /*
 function eventInfo(){

--- a/assets/js/manage_events_main.js
+++ b/assets/js/manage_events_main.js
@@ -35,8 +35,8 @@ function createdEventHist() {
 		$( "#dialog-form" ).dialog();
 	});
 
-    //BUTTON TO CREATE NEW EVENT - SUBMIT BUTTON IN CREATE_EVENT.PHP
-    $('#signupbtn').on('click',function(e){
+     //BUTTON TO CREATE NEW EVENT - SUBMIT BUTTON IN CREATE_EVENT.PHP
+     $('#signupbtn').on('click',function(e){
         e.preventDefault();
         var title = $('#title').val();
         var description = $('#description').val();
@@ -44,7 +44,6 @@ function createdEventHist() {
         var dateEnd = $('#dateEnd').val();
         var creatorID = $('#creatorID').val();    
         var location = $('#location').val();
-        //var RSVPLim = $('#RSVPLim').val();
         $.ajax({
             url:"../Schedule-it/database/event/insert.php",
             type:"POST",
@@ -78,9 +77,9 @@ function createdEventHist() {
         var location = $('#location').val();
         title = $('#title').val('');
         description = $('#description').val('');
-        location = $('#location').val('');
-        dateStart = $('#dateStart').val('');
-        dateEnd = $('#dateEnd').val('');
+		location = $('#location').val('');
+		dateStart = $('#dateStart').val('');
+		dateEnd = $('#dateEnd').val('');
     });
 
 /*

--- a/assets/js/view_history.js
+++ b/assets/js/view_history.js
@@ -1,4 +1,5 @@
 // java script for user's event history page
+// *VERY IMPORTANT: ALSO FOR THE HOMEPAGE
 function createdEventHist() {
     let mostRecent;
     if (pastEvents.length > 0) {
@@ -71,14 +72,15 @@ function createdEventHist() {
 }
 
     // GIVES FUNCTIONALITY TO X BUTTON. Now actually clears form when clicked
-    // Also does not work with dates
     $(document).on('click', '.ui-dialog-titlebar-close', function(){
         var title = $('#title').val();
         var description = $('#description').val();
         var location = $('#location').val();
         title = $('#title').val('');
         description = $('#description').val('');
-        location = $('#location').val('');
+		location = $('#location').val('');
+		dateStart = $('#dateStart').val('');
+		dateEnd = $('#dateEnd').val('');
     });
 
 function reservationHist() {

--- a/assets/js/view_history.js
+++ b/assets/js/view_history.js
@@ -35,9 +35,6 @@ function createdEventHist() {
 		$( "#dialog-form" ).dialog();
 	});
 
-    calendar.render();
-}
-
     //BUTTON TO CREATE NEW EVENT - SUBMIT BUTTON IN CREATE_EVENT.PHP
     $('#signupbtn').on('click',function(e){
         e.preventDefault();
@@ -63,23 +60,13 @@ function createdEventHist() {
             }
         })
     // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
-    // Don't try to use this for the dates or after submitting, no matter where
-    // you click on the calendar it will just say mm/dd/yyyy until you refresh
     title = $('#title').val('');
     description = $('#description').val('');
     location = $('#location').val('');
     });
 
-    // GIVES FUNCTIONALITY TO X BUTTON. Now actually clears form when clicked
-    // Also does not work with dates
-    $(document).on('click', '.ui-dialog-titlebar-close', function(){
-        var title = $('#title').val();
-        var description = $('#description').val();
-        var location = $('#location').val();
-        title = $('#title').val('');
-        description = $('#description').val('');
-        location = $('#location').val('');
-    });
+    calendar.render();
+}
 
 function reservationHist() {
     let mostRecent;

--- a/assets/js/view_history.js
+++ b/assets/js/view_history.js
@@ -38,6 +38,49 @@ function createdEventHist() {
     calendar.render();
 }
 
+    //BUTTON TO CREATE NEW EVENT - SUBMIT BUTTON IN CREATE_EVENT.PHP
+    $('#signupbtn').on('click',function(e){
+        e.preventDefault();
+        var title = $('#title').val();
+        var description = $('#description').val();
+        var dateStart = $('#dateStart').val();
+        var dateEnd = $('#dateEnd').val();
+        var creatorID = $('#creatorID').val();    
+        var location = $('#location').val();
+        $.ajax({
+            url:"../Schedule-it/database/event/insert.php",
+            type:"POST",
+            data: {title:title, description:description, dateStart:dateStart, dateEnd:dateEnd, creatorID:creatorID, location:location},
+            complete: function() {
+                $( "#dialog-form" ).dialog( "close" );
+            },
+            success: function(){
+                calendar.refetchEvents();
+                alert("Added Successfully");
+            },
+            error: function(error) {
+                console.log(error);
+            }
+        })
+    // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
+    // Don't try to use this for the dates or after submitting, no matter where
+    // you click on the calendar it will just say mm/dd/yyyy until you refresh
+    title = $('#title').val('');
+    description = $('#description').val('');
+    location = $('#location').val('');
+    });
+
+    // GIVES FUNCTIONALITY TO X BUTTON. Now actually clears form when clicked
+    // Also does not work with dates
+    $(document).on('click', '.ui-dialog-titlebar-close', function(){
+        var title = $('#title').val();
+        var description = $('#description').val();
+        var location = $('#location').val();
+        title = $('#title').val('');
+        description = $('#description').val('');
+        location = $('#location').val('');
+    });
+
 function reservationHist() {
     let mostRecent;
     if (pastEvents.length > 0) {

--- a/assets/js/view_history.js
+++ b/assets/js/view_history.js
@@ -59,11 +59,16 @@ function createdEventHist() {
                 console.log(error);
             }
         })
+    // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
+    title = $('#title').val('');
+    description = $('#description').val('');
+    location = $('#location').val('');
+    dateStart = $('#dateStart').val('');
+    dateEnd = $('#dateEnd').val('');
     });
 
     calendar.render();
 }
-
 
 function reservationHist() {
     let mostRecent;

--- a/assets/js/view_history.js
+++ b/assets/js/view_history.js
@@ -35,38 +35,6 @@ function createdEventHist() {
 		$( "#dialog-form" ).dialog();
 	});
 
-    //BUTTON TO CREATE NEW EVENT - SUBMIT BUTTON IN CREATE_EVENT.PHP
-    $('#signupbtn').on('click',function(e){
-        e.preventDefault();
-        var title = $('#title').val();
-        var description = $('#description').val();
-        var dateStart = $('#dateStart').val();
-        var dateEnd = $('#dateEnd').val();
-        var creatorID = $('#creatorID').val();    
-        var location = $('#location').val();
-        $.ajax({
-            url:"../Schedule-it/database/event/insert.php",
-            type:"POST",
-            data: {title:title, description:description, dateStart:dateStart, dateEnd:dateEnd, creatorID:creatorID, location:location},
-            complete: function() {
-                $( "#dialog-form" ).dialog( "close" );
-            },
-            success: function(){
-                calendar.refetchEvents();
-                alert("Added Successfully");
-            },
-            error: function(error) {
-                console.log(error);
-            }
-        })
-    // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
-    title = $('#title').val('');
-    description = $('#description').val('');
-    location = $('#location').val('');
-    dateStart = $('#dateStart').val('');
-    dateEnd = $('#dateEnd').val('');
-    });
-
     calendar.render();
 }
 

--- a/assets/js/view_history.js
+++ b/assets/js/view_history.js
@@ -62,11 +62,24 @@ function createdEventHist() {
     // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
     title = $('#title').val('');
     description = $('#description').val('');
-    location = $('#location').val('');
+	location = $('#location').val('');
+	dateStart = $('#dateStart').val('');
+	dateEnd = $('#dateEnd').val('');
     });
 
     calendar.render();
 }
+
+    // GIVES FUNCTIONALITY TO X BUTTON. Now actually clears form when clicked
+    // Also does not work with dates
+    $(document).on('click', '.ui-dialog-titlebar-close', function(){
+        var title = $('#title').val();
+        var description = $('#description').val();
+        var location = $('#location').val();
+        title = $('#title').val('');
+        description = $('#description').val('');
+        location = $('#location').val('');
+    });
 
 function reservationHist() {
     let mostRecent;

--- a/assets/js/view_history.js
+++ b/assets/js/view_history.js
@@ -63,9 +63,7 @@ function createdEventHist() {
     // THIS CODE CLEARS THE FORM. Without it, data stays even after submitting
     title = $('#title').val('');
     description = $('#description').val('');
-	location = $('#location').val('');
-	dateStart = $('#dateStart').val('');
-	dateEnd = $('#dateEnd').val('');
+    location = $('#location').val('');
     });
 
     calendar.render();

--- a/calendar.php
+++ b/calendar.php
@@ -263,9 +263,13 @@
       <label for="dateEnd">End Date: </label>
           <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required>
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
+      <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 
       <!-- Allow form submission with keyboard without duplicating the dialog button -->
       <input type="submit" id="signupbtn">
+      <? php
+      $_POST = array();
+      ?>
     </fieldset>
   </form>
 </div>
@@ -308,6 +312,9 @@
       <!-- Allow form submission with keyboard without duplicating the dialog button -->
       <button type="button" id="edit-slotbtn">Edit Slots</button>
       <button type="button" id="edit-submit">Confirm Changes</button>
+      <? php
+      $_POST = array();
+      ?>
     </fieldset>
   </form>
 </div>

--- a/calendar.php
+++ b/calendar.php
@@ -267,11 +267,6 @@
 
       <!-- Allow form submission with keyboard without duplicating the dialog button -->
       <input type="button" value="Submit" id="signupbtn" onclick="submitForm()">
-      <script>
-function myFunction() {
-    document.getElementById("calcreate").reset();
-}
-</script>
     </fieldset>
   </form>
 </div>

--- a/calendar.php
+++ b/calendar.php
@@ -253,10 +253,8 @@
   <input type="hidden" id="date" name="date">
       <input type="text" name="title" id="title" placeholder="Event title" class="text ui-widget-content ui-corner-all" required>
 
-      <label for="description">Description: </label>
       <input type="text" name="description" id="description" placeholder="Description" class="text ui-widget-content ui-corner-all">
 
-      <label for="location">Location:  </label>
       <input type="text" name="location" id="location" placeholder="Location" class="text ui-widget-content ui-corner-all">  
 
       <label for="dateStart">Start Date: </label>

--- a/calendar.php
+++ b/calendar.php
@@ -250,17 +250,17 @@
 
 <form>
   <fieldset>
-  <input type="text" name="title" id="title" placeholder="Event Title" value="" class="text ui-widget-content ui-corner-all" required>
+  <input type="text" name="titleedit" id="titleedit" value="" placeholder="Event title" class="text ui-widget-content ui-corner-all">
 
-  <input type="text" name="description" id="description" placeholder="Description" class="text ui-widget-content ui-corner-all">
+<input type="text" name="descriptionedit" id="descriptionedit" placeholder="Description" class="text ui-widget-content ui-corner-all">
 
-  <input type="text" name="location" id="location" placeholder="Location" class="text ui-widget-content ui-corner-all">  
+<input type="text" name="locationedit" id="locationedit" placeholder="Location" class="text ui-widget-content ui-corner-all">  
 
-  <label for="dateStart">Start Date: </label>
-  <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required></td>
+<label for="dateStartEdit">Start Date: </label>
+    <input type="date" name="dateStartEdit" id="dateStartEdit" class="text ui-widget-content ui-corner-all">
 
-  <label for="dateEnd">End Date: </label>
-  <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required></td>
+<label for="dateEndEdit">End Date: </label>
+    <input type="date" name="dateEndEdit" id="dateEndEdit" class="text ui-widget-content ui-corner-all">
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 
@@ -292,17 +292,17 @@
 
 <form>
   <fieldset>
-  <input type="text" name="title" id="title" placeholder="Event Title" value="" class="text ui-widget-content ui-corner-all" required>
+  <input type="text" name="titleedit" id="titleedit" value="" placeholder="Event title" class="text ui-widget-content ui-corner-all">
 
-  <input type="text" name="description" id="description" placeholder="Description" class="text ui-widget-content ui-corner-all">
+<input type="text" name="descriptionedit" id="descriptionedit" placeholder="Description" class="text ui-widget-content ui-corner-all">
 
-  <input type="text" name="location" id="location" placeholder="Location" class="text ui-widget-content ui-corner-all">  
+<input type="text" name="locationedit" id="locationedit" placeholder="Location" class="text ui-widget-content ui-corner-all">  
 
-  <label for="dateStart">Start Date: </label>
-  <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required></td>
+<label for="dateStartEdit">Start Date: </label>
+    <input type="date" name="dateStartEdit" id="dateStartEdit" class="text ui-widget-content ui-corner-all">
 
-  <label for="dateEnd">End Date: </label>
-  <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required></td>
+<label for="dateEndEdit">End Date: </label>
+    <input type="date" name="dateEndEdit" id="dateEndEdit" class="text ui-widget-content ui-corner-all">
 
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <!-- Allow form submission with keyboard without duplicating the dialog button -->

--- a/calendar.php
+++ b/calendar.php
@@ -250,19 +250,21 @@
 
 <form>
   <fieldset>
-  <input type="hidden" id="dateedit" name="dateedit" value="">
+  <input type="hidden" id="date" name="date">
+      <label for="title">Event title: </label>
+      <input type="text" name="title" id="title" class="text ui-widget-content ui-corner-all" required>
 
-  <input type="text" name="titleedit" id="titleedit" value="" placeholder="Event title" class="text ui-widget-content ui-corner-all">
+      <label for="description">Description: </label>
+      <input type="text" name="description" id="description" class="text ui-widget-content ui-corner-all">
 
-<input type="text" name="descriptionedit" id="descriptionedit" placeholder="Description" class="text ui-widget-content ui-corner-all">
+      <label for="location">Location:  </label>
+      <input type="text" name="location" id="location" class="text ui-widget-content ui-corner-all">  
 
-<input type="text" name="locationedit" id="locationedit" placeholder="Location" class="text ui-widget-content ui-corner-all">  
+      <label for="dateStart">Start Date: </label>
+          <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required>
 
-<label for="dateStartEdit">Start Date: </label>
-    <input type="date" name="dateStartEdit" id="dateStartEdit" class="text ui-widget-content ui-corner-all">
-
-<label for="dateEndEdit">End Date: </label>
-    <input type="date" name="dateEndEdit" id="dateEndEdit" class="text ui-widget-content ui-corner-all">
+      <label for="dateEnd">End Date: </label>
+          <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required>
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 

--- a/calendar.php
+++ b/calendar.php
@@ -251,7 +251,6 @@
 <form>
   <fieldset>
   <input type="hidden" id="date" name="date">
-      <label for="title">Event title: </label>
       <input type="text" name="title" id="title" placeholder="Event title" class="text ui-widget-content ui-corner-all" required>
 
       <label for="description">Description: </label>

--- a/calendar.php
+++ b/calendar.php
@@ -288,8 +288,6 @@
 
 <!-- FORM FOR EDIT EVENT -->
 <div id="edit-form" style="display:none;" title="Edit Current Event">
-   <p class="validateTips">All form fields are required.</p>
-      <button type="button" id="edit-slotbtn">Edit Slots</button>
 
 <form>
   <fieldset>
@@ -309,6 +307,7 @@
 
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <!-- Allow form submission with keyboard without duplicating the dialog button -->
+      <button type="button" id="edit-slotbtn">Edit Slots</button>
       <button type="button" id="edit-submit">Confirm Changes</button>
     </fieldset>
   </form>

--- a/calendar.php
+++ b/calendar.php
@@ -248,7 +248,7 @@
 <div id="dialog-form" style="display:none;" title="Create new event">
    <p class="validateTips">All form fields are required.</p>
 
-<form name ="calcreate">
+<form id ="calcreate">
   <fieldset>
   <input type="hidden" id="date" name="date">
       <input type="text" name="title" id="title" placeholder="Event title" class="text ui-widget-content ui-corner-all" required>
@@ -267,21 +267,14 @@
 
       <!-- Allow form submission with keyboard without duplicating the dialog button -->
       <input type="button" value="Submit" id="signupbtn" onclick="submitForm()">
+      <script>
+function myFunction() {
+    document.getElementById("calcreate").reset();
+}
+</script>
     </fieldset>
   </form>
 </div>
-<script>
-      function submitForm() {
-   // Get the first form with the name
-   // Usually the form name is not repeated
-   // but duplicate names are possible in HTML
-   // Therefore to work around the issue, enforce the correct index
-   var frm = document.getElementsByName('calcreate')[0];
-   frm.submit(); // Submit the form
-   frm.reset();  // Reset all form data
-   return false; // Prevent page refresh
-}
-</script>
 
 <!-- FORM FOR EDIT AND DELETE BUTTONS -->
 <div id="edit-delete" style="display:none;" title="Edit or Delete">

--- a/calendar.php
+++ b/calendar.php
@@ -263,7 +263,6 @@
       <label for="dateEnd">End Date: </label>
           <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required>
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
-      <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 
       <!-- Allow form submission with keyboard without duplicating the dialog button -->
       <input type="submit" id="signupbtn">

--- a/calendar.php
+++ b/calendar.php
@@ -252,13 +252,13 @@
   <fieldset>
   <input type="hidden" id="date" name="date">
       <label for="title">Event title: </label>
-      <input type="text" name="title" id="title" class="text ui-widget-content ui-corner-all" required>
+      <input type="text" name="title" id="title" placeholder="Event title" class="text ui-widget-content ui-corner-all" required>
 
       <label for="description">Description: </label>
-      <input type="text" name="description" id="description" class="text ui-widget-content ui-corner-all">
+      <input type="text" name="description" id="description" placeholder="Description" class="text ui-widget-content ui-corner-all">
 
       <label for="location">Location:  </label>
-      <input type="text" name="location" id="location" class="text ui-widget-content ui-corner-all">  
+      <input type="text" name="location" id="location" placeholder="Location" class="text ui-widget-content ui-corner-all">  
 
       <label for="dateStart">Start Date: </label>
           <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required>

--- a/calendar.php
+++ b/calendar.php
@@ -266,7 +266,7 @@
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 
       <!-- Allow form submission with keyboard without duplicating the dialog button -->
-      <input type="submit" id="signupbtn">
+      <input type="button" value="Submit" id="signupbtn" onclick="submitForm()">
     </fieldset>
   </form>
 </div>
@@ -295,15 +295,15 @@
 
   <input type="text" name="titleedit" id="titleedit" value="" placeholder="Event title" class="text ui-widget-content ui-corner-all">
 
-<input type="text" name="descriptionedit" id="descriptionedit" placeholder="Description" class="text ui-widget-content ui-corner-all">
+  <input type="text" name="descriptionedit" id="descriptionedit" placeholder="Description" class="text ui-widget-content ui-corner-all">
 
-<input type="text" name="locationedit" id="locationedit" placeholder="Location" class="text ui-widget-content ui-corner-all">  
+  <input type="text" name="locationedit" id="locationedit" placeholder="Location" class="text ui-widget-content ui-corner-all">  
 
-<label for="dateStartEdit">Start Date: </label>
-    <input type="date" name="dateStartEdit" id="dateStartEdit" class="text ui-widget-content ui-corner-all">
+  <label for="dateStartEdit">Start Date: </label>
+      <input type="date" name="dateStartEdit" id="dateStartEdit" class="text ui-widget-content ui-corner-all">
 
-<label for="dateEndEdit">End Date: </label>
-    <input type="date" name="dateEndEdit" id="dateEndEdit" class="text ui-widget-content ui-corner-all">
+  <label for="dateEndEdit">End Date: </label>
+      <input type="date" name="dateEndEdit" id="dateEndEdit" class="text ui-widget-content ui-corner-all">
 
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <!-- Allow form submission with keyboard without duplicating the dialog button -->

--- a/calendar.php
+++ b/calendar.php
@@ -250,22 +250,17 @@
 
 <form>
   <fieldset>
-      <input type="hidden" id="date" name="date">
-      <label for="title">Event title: </label>
-      <input type="text" name="title" id="title" class="text ui-widget-content ui-corner-all" required>
+  <input type="text" name="title" id="title" placeholder="Event Title" value="" class="text ui-widget-content ui-corner-all" required>
 
-      <label for="description">Description: </label>
-      <input type="text" name="description" id="description" class="text ui-widget-content ui-corner-all">
+  <input type="text" name="description" id="description" placeholder="Description" class="text ui-widget-content ui-corner-all">
 
-      <label for="location">Location:  </label>
-      <input type="text" name="location" id="location" class="text ui-widget-content ui-corner-all">  
+  <input type="text" name="location" id="location" placeholder="Location" class="text ui-widget-content ui-corner-all">  
 
-      <label for="dateStart">Start Date: </label>
-          <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required>
+  <label for="dateStart">Start Date: </label>
+  <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required></td>
 
-      <label for="dateEnd">End Date: </label>
-          <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required>
-
+  <label for="dateEnd">End Date: </label>
+  <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required></td>
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 
@@ -297,21 +292,17 @@
 
 <form>
   <fieldset>
-      <input type="hidden" id="dateedit" name="dateedit" value="">
-      <label for="titleedit">Event title: </label>
-      <input type="text" name="titleedit" id="titleedit" value="" class="text ui-widget-content ui-corner-all">
+  <input type="text" name="title" id="title" placeholder="Event Title" value="" class="text ui-widget-content ui-corner-all" required>
 
-      <label for="descriptionedit">Description: </label>
-      <input type="text" name="descriptionedit" id="descriptionedit" class="text ui-widget-content ui-corner-all">
+  <input type="text" name="description" id="description" placeholder="Description" class="text ui-widget-content ui-corner-all">
 
-      <label for="locationedit">Location:  </label>
-      <input type="text" name="locationedit" id="locationedit" class="text ui-widget-content ui-corner-all">  
+  <input type="text" name="location" id="location" placeholder="Location" class="text ui-widget-content ui-corner-all">  
 
-      <label for="dateStartEdit">Start Date: </label>
-          <input type="date" name="dateStartEdit" id="dateStartEdit" class="text ui-widget-content ui-corner-all">
+  <label for="dateStart">Start Date: </label>
+  <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required></td>
 
-      <label for="dateEndEdit">End Date: </label>
-          <input type="date" name="dateEndEdit" id="dateEndEdit" class="text ui-widget-content ui-corner-all">
+  <label for="dateEnd">End Date: </label>
+  <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required></td>
 
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <!-- Allow form submission with keyboard without duplicating the dialog button -->

--- a/calendar.php
+++ b/calendar.php
@@ -267,8 +267,10 @@
 
       <!-- Allow form submission with keyboard without duplicating the dialog button -->
       <input type="button" value="Submit" id="signupbtn" onclick="submitForm()">
-
-      <script>
+    </fieldset>
+  </form>
+</div>
+<script>
       function submitForm() {
    // Get the first form with the name
    // Usually the form name is not repeated
@@ -280,10 +282,6 @@
    return false; // Prevent page refresh
 }
 </script>
-    </fieldset>
-  </form>
-</div>
-
 
 <!-- FORM FOR EDIT AND DELETE BUTTONS -->
 <div id="edit-delete" style="display:none;" title="Edit or Delete">

--- a/calendar.php
+++ b/calendar.php
@@ -248,7 +248,7 @@
 <div id="dialog-form" style="display:none;" title="Create new event">
    <p class="validateTips">All form fields are required.</p>
 
-<form>
+<form id = "calcreate">
   <fieldset>
   <input type="hidden" id="date" name="date">
       <input type="text" name="title" id="title" placeholder="Event title" class="text ui-widget-content ui-corner-all" required>
@@ -267,9 +267,6 @@
 
       <!-- Allow form submission with keyboard without duplicating the dialog button -->
       <input type="submit" id="signupbtn">
-      <? php
-      $_POST = array();
-      ?>
     </fieldset>
   </form>
 </div>
@@ -312,9 +309,6 @@
       <!-- Allow form submission with keyboard without duplicating the dialog button -->
       <button type="button" id="edit-slotbtn">Edit Slots</button>
       <button type="button" id="edit-submit">Confirm Changes</button>
-      <? php
-      $_POST = array();
-      ?>
     </fieldset>
   </form>
 </div>

--- a/calendar.php
+++ b/calendar.php
@@ -248,7 +248,7 @@
 <div id="dialog-form" style="display:none;" title="Create new event">
    <p class="validateTips">All form fields are required.</p>
 
-<form id = "calcreate">
+<form name ="calcreate">
   <fieldset>
   <input type="hidden" id="date" name="date">
       <input type="text" name="title" id="title" placeholder="Event title" class="text ui-widget-content ui-corner-all" required>

--- a/calendar.php
+++ b/calendar.php
@@ -267,6 +267,19 @@
 
       <!-- Allow form submission with keyboard without duplicating the dialog button -->
       <input type="button" value="Submit" id="signupbtn" onclick="submitForm()">
+
+      <script>
+      function submitForm() {
+   // Get the first form with the name
+   // Usually the form name is not repeated
+   // but duplicate names are possible in HTML
+   // Therefore to work around the issue, enforce the correct index
+   var frm = document.getElementsByName('calcreate')[0];
+   frm.submit(); // Submit the form
+   frm.reset();  // Reset all form data
+   return false; // Prevent page refresh
+}
+</script>
     </fieldset>
   </form>
 </div>

--- a/calendar.php
+++ b/calendar.php
@@ -250,6 +250,8 @@
 
 <form>
   <fieldset>
+  <input type="hidden" id="dateedit" name="dateedit" value="">
+
   <input type="text" name="titleedit" id="titleedit" value="" placeholder="Event title" class="text ui-widget-content ui-corner-all">
 
 <input type="text" name="descriptionedit" id="descriptionedit" placeholder="Description" class="text ui-widget-content ui-corner-all">
@@ -292,6 +294,8 @@
 
 <form>
   <fieldset>
+  <input type="hidden" id="dateedit" name="dateedit" value="">
+
   <input type="text" name="titleedit" id="titleedit" value="" placeholder="Event title" class="text ui-widget-content ui-corner-all">
 
 <input type="text" name="descriptionedit" id="descriptionedit" placeholder="Description" class="text ui-widget-content ui-corner-all">

--- a/eventmanagement.php
+++ b/eventmanagement.php
@@ -201,17 +201,17 @@ div#users-contain table td, div#users-contain table th { border: 1px solid #eee;
 
 <form>
   <fieldset>
-    <input type="text" name="title" id="title" placeholder="Event Title" value="" class="text ui-widget-content ui-corner-all" required>
+      <input type="text" name="titleedit" id="titleedit" value="" placeholder="Event title" class="text ui-widget-content ui-corner-all">
 
-    <input type="text" name="description" id="description" placeholder="Description" class="text ui-widget-content ui-corner-all">
+      <input type="text" name="descriptionedit" id="descriptionedit" placeholder="Description" class="text ui-widget-content ui-corner-all">
 
-    <input type="text" name="location" id="location" placeholder="Location" class="text ui-widget-content ui-corner-all">  
+      <input type="text" name="locationedit" id="locationedit" placeholder="Location" class="text ui-widget-content ui-corner-all">  
 
-    <label for="dateStart">Start Date: </label>
-    <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required></td>
+      <label for="dateStartEdit">Start Date: </label>
+          <input type="date" name="dateStartEdit" id="dateStartEdit" class="text ui-widget-content ui-corner-all">
 
-    <label for="dateEnd">End Date: </label>
-    <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required></td>
+      <label for="dateEndEdit">End Date: </label>
+          <input type="date" name="dateEndEdit" id="dateEndEdit" class="text ui-widget-content ui-corner-all">
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 

--- a/eventmanagement.php
+++ b/eventmanagement.php
@@ -201,22 +201,17 @@ div#users-contain table td, div#users-contain table th { border: 1px solid #eee;
 
 <form>
   <fieldset>
-      <input type="hidden" id="date" name="date">
-      <label for="title">Event title: </label>
-      <input type="text" name="title" id="title" class="text ui-widget-content ui-corner-all" required>
+    <input type="text" name="title" id="title" placeholder="Event Title" value="" class="text ui-widget-content ui-corner-all" required>
 
-      <label for="description">Description: </label>
-      <input type="text" name="description" id="description" class="text ui-widget-content ui-corner-all">
+    <input type="text" name="description" id="description" placeholder="Description" class="text ui-widget-content ui-corner-all">
 
-      <label for="location">Location:  </label>
-      <input type="text" name="location" id="location" class="text ui-widget-content ui-corner-all">  
+    <input type="text" name="location" id="location" placeholder="Location" class="text ui-widget-content ui-corner-all">  
 
-      <label for="dateStart">Start Date: </label>
-          <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required>
+    <label for="dateStart">Start Date: </label>
+    <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required></td>
 
-      <label for="dateEnd">End Date: </label>
-          <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required>
-
+    <label for="dateEnd">End Date: </label>
+    <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required></td>
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 

--- a/eventmanagement.php
+++ b/eventmanagement.php
@@ -201,6 +201,8 @@ div#users-contain table td, div#users-contain table th { border: 1px solid #eee;
 
 <form>
   <fieldset>
+  <input type="hidden" id="dateedit" name="dateedit" value="">
+
       <input type="text" name="titleedit" id="titleedit" value="" placeholder="Event title" class="text ui-widget-content ui-corner-all">
 
       <input type="text" name="descriptionedit" id="descriptionedit" placeholder="Description" class="text ui-widget-content ui-corner-all">

--- a/eventmanagement.php
+++ b/eventmanagement.php
@@ -200,20 +200,22 @@ div#users-contain table td, div#users-contain table th { border: 1px solid #eee;
 <p class="validateTips">All form fields are required.</p>
 
 <form>
-  <fieldset>
-  <input type="hidden" id="dateedit" name="dateedit" value="">
+<fieldset>
+  <input type="hidden" id="date" name="date">
+      <input type="text" name="title" id="title" placeholder="Event title" class="text ui-widget-content ui-corner-all" required>
 
-      <input type="text" name="titleedit" id="titleedit" value="" placeholder="Event title" class="text ui-widget-content ui-corner-all">
+      <input type="text" name="description" id="description" placeholder="Description" class="text ui-widget-content ui-corner-all">
 
-      <input type="text" name="descriptionedit" id="descriptionedit" placeholder="Description" class="text ui-widget-content ui-corner-all">
+      <input type="text" name="location" id="location" placeholder="Location" class="text ui-widget-content ui-corner-all">  
 
-      <input type="text" name="locationedit" id="locationedit" placeholder="Location" class="text ui-widget-content ui-corner-all">  
+      <label for="dateStart">Start Date: </label>
+          <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required>
 
-      <label for="dateStartEdit">Start Date: </label>
-          <input type="date" name="dateStartEdit" id="dateStartEdit" class="text ui-widget-content ui-corner-all">
+      <label for="dateEnd">End Date: </label>
+          <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required>
+          <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
+      <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 
-      <label for="dateEndEdit">End Date: </label>
-          <input type="date" name="dateEndEdit" id="dateEndEdit" class="text ui-widget-content ui-corner-all">
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 

--- a/eventmanagement.php
+++ b/eventmanagement.php
@@ -77,8 +77,6 @@
 
   <!-- fontawesome for icon usage eg. navbar hamburger icon -->
   <script src="https://kit.fontawesome.com/96abf9bb58.js" crossorigin="anonymous"></script>
-  
-
 
   <!--fullcalendar-->
   <!--Use daygrid-views for homepage -->

--- a/eventmanagement.php
+++ b/eventmanagement.php
@@ -212,9 +212,7 @@ div#users-contain table td, div#users-contain table th { border: 1px solid #eee;
           <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required>
 
       <label for="dateEnd">End Date: </label>
-          <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required>
-          <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
-      <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
+          <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required>  
 
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   

--- a/homepage.php
+++ b/homepage.php
@@ -99,6 +99,7 @@
 	<!-- javascript files -->
 	<script src="./assets/js/main.js"></script>
 	<script src="./assets/js/view_history.js"></script>
+	<script src="./assets/js/event.js"></script> 
 
 
 	<!-- fontawesome for icon usage eg. navbar hamburger icon -->
@@ -252,10 +253,7 @@ div#users-contain table td, div#users-contain table th { border: 1px solid #eee;
       <label for="dateEnd">End Date: </label>
           <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required>
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
-      <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
-
-          <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
-      <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
+      <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />     
 
       <!-- Allow form submission with keyboard without duplicating the dialog button -->
       <input type="submit" id="signupbtn">

--- a/homepage.php
+++ b/homepage.php
@@ -239,22 +239,17 @@ div#users-contain table td, div#users-contain table th { border: 1px solid #eee;
 
 <form>
   <fieldset>
-      <input type="hidden" id="date" name="date">
-      <label for="title">Event title: </label>
-      <input type="text" name="title" id="title" class="text ui-widget-content ui-corner-all" required>
+	<input type="text" name="title" id="title" placeholder="Event Title" value="" class="text ui-widget-content ui-corner-all" required>
 
-      <label for="description">Description: </label>
-      <input type="text" name="description" id="description" class="text ui-widget-content ui-corner-all">
+	<input type="text" name="description" id="description" placeholder="Description" class="text ui-widget-content ui-corner-all">
 
-      <label for="location">Location:  </label>
-      <input type="text" name="location" id="location" class="text ui-widget-content ui-corner-all">  
+	<input type="text" name="location" id="location" placeholder="Location" class="text ui-widget-content ui-corner-all">  
 
-      <label for="dateStart">Start Date: </label>
-          <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required>
+	<label for="dateStart">Start Date: </label>
+	<input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required></td>
 
-      <label for="dateEnd">End Date: </label>
-          <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required>
-
+	<label for="dateEnd">End Date: </label>
+	<input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required></td>
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 

--- a/homepage.php
+++ b/homepage.php
@@ -239,17 +239,17 @@ div#users-contain table td, div#users-contain table th { border: 1px solid #eee;
 
 <form>
   <fieldset>
-	<input type="text" name="title" id="title" placeholder="Event Title" value="" class="text ui-widget-content ui-corner-all" required>
+  <input type="text" name="titleedit" id="titleedit" value="" placeholder="Event title" class="text ui-widget-content ui-corner-all">
 
-	<input type="text" name="description" id="description" placeholder="Description" class="text ui-widget-content ui-corner-all">
+<input type="text" name="descriptionedit" id="descriptionedit" placeholder="Description" class="text ui-widget-content ui-corner-all">
 
-	<input type="text" name="location" id="location" placeholder="Location" class="text ui-widget-content ui-corner-all">  
+<input type="text" name="locationedit" id="locationedit" placeholder="Location" class="text ui-widget-content ui-corner-all">  
 
-	<label for="dateStart">Start Date: </label>
-	<input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required></td>
+<label for="dateStartEdit">Start Date: </label>
+	<input type="date" name="dateStartEdit" id="dateStartEdit" class="text ui-widget-content ui-corner-all">
 
-	<label for="dateEnd">End Date: </label>
-	<input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required></td>
+<label for="dateEndEdit">End Date: </label>
+	<input type="date" name="dateEndEdit" id="dateEndEdit" class="text ui-widget-content ui-corner-all">
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 

--- a/homepage.php
+++ b/homepage.php
@@ -238,19 +238,22 @@ div#users-contain table td, div#users-contain table th { border: 1px solid #eee;
 <p class="validateTips">All form fields are required.</p>
 
 <form>
-  <fieldset>
-  <input type="hidden" id="dateedit" name="dateedit" value="">
-  <input type="text" name="titleedit" id="titleedit" value="" placeholder="Event title" class="text ui-widget-content ui-corner-all">
+<fieldset>
+  <input type="hidden" id="date" name="date">
+      <input type="text" name="title" id="title" placeholder="Event title" class="text ui-widget-content ui-corner-all" required>
 
-<input type="text" name="descriptionedit" id="descriptionedit" placeholder="Description" class="text ui-widget-content ui-corner-all">
+      <input type="text" name="description" id="description" placeholder="Description" class="text ui-widget-content ui-corner-all">
 
-<input type="text" name="locationedit" id="locationedit" placeholder="Location" class="text ui-widget-content ui-corner-all">  
+      <input type="text" name="location" id="location" placeholder="Location" class="text ui-widget-content ui-corner-all">  
 
-<label for="dateStartEdit">Start Date: </label>
-	<input type="date" name="dateStartEdit" id="dateStartEdit" class="text ui-widget-content ui-corner-all">
+      <label for="dateStart">Start Date: </label>
+          <input type="date" name="dateStart" id="dateStart" class="text ui-widget-content ui-corner-all" required>
 
-<label for="dateEndEdit">End Date: </label>
-	<input type="date" name="dateEndEdit" id="dateEndEdit" class="text ui-widget-content ui-corner-all">
+      <label for="dateEnd">End Date: </label>
+          <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required>
+          <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
+      <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
+
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 

--- a/homepage.php
+++ b/homepage.php
@@ -239,6 +239,7 @@ div#users-contain table td, div#users-contain table th { border: 1px solid #eee;
 
 <form>
   <fieldset>
+  <input type="hidden" id="dateedit" name="dateedit" value="">
   <input type="text" name="titleedit" id="titleedit" value="" placeholder="Event title" class="text ui-widget-content ui-corner-all">
 
 <input type="text" name="descriptionedit" id="descriptionedit" placeholder="Description" class="text ui-widget-content ui-corner-all">

--- a/homepage.php
+++ b/homepage.php
@@ -252,7 +252,10 @@ div#users-contain table td, div#users-contain table th { border: 1px solid #eee;
       <label for="dateEnd">End Date: </label>
           <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required>
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
-      <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />     
+      <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
+
+          <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
+      <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 
       <!-- Allow form submission with keyboard without duplicating the dialog button -->
       <input type="submit" id="signupbtn">

--- a/homepage.php
+++ b/homepage.php
@@ -99,7 +99,6 @@
 	<!-- javascript files -->
 	<script src="./assets/js/main.js"></script>
 	<script src="./assets/js/view_history.js"></script>
-	<script src="./assets/js/event.js"></script> 
 
 
 	<!-- fontawesome for icon usage eg. navbar hamburger icon -->

--- a/homepage.php
+++ b/homepage.php
@@ -251,8 +251,6 @@ div#users-contain table td, div#users-contain table th { border: 1px solid #eee;
 
       <label for="dateEnd">End Date: </label>
           <input type="date" name="dateEnd" id="dateEnd" class="text ui-widget-content ui-corner-all" required>
-          <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
-      <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   
 
           <!--THIS IS CREATOR_ID -- SHOULD GET FROM SESSION -->
       <input type="hidden" name="creatorID" id="creatorID" value="<?php echo $user->id;?>" />   


### PR DESCRIPTION
- Streamlines event creation box. Also moved edit slots button to bottom of event edit box.
- Closes #71 -- text no longer sticks around once submit button is clicked on calendar and homepage. This doesn't work for dates on the calendar page, just for title/location/description. Works for dates on homepage. Am still working on adding this functionality to the event management page.
- Added functionality for X button -- text now disappears from form once the X is clicked on calendar and homepage. I also tried to get the create/edit events box itself to disappear once user clicks outside of it and was partially successful, but this created a lot of bugs so I have dropped it for now.
- Both work for the create event button and for creating events via the calendar.