### PR TITLE
Small bug fix: empty list error messages

### DIFF
--- a/assets/js/view_history.js
+++ b/assets/js/view_history.js
@@ -100,7 +100,7 @@ function createdEventHist() {
  */
 function reservationHist() {
     let mostRecent;
-    if (pastEvents.length > 0) {
+    if (pastReservations.length > 0) {
         // fullcalendar.io can handle getting the date from a string with the date and time
         mostRecent = pastReservations[pastReservations.length - 1]['start']; 
     }
@@ -136,7 +136,7 @@ function reservationHist() {
  */
 function inviteHist() {
     let mostRecent;
-    if (pastEvents.length > 0) {
+    if (pastInvites.length > 0) {
         // fullcalendar.io can handle getting the date from a string with the date and time
         mostRecent = pastInvites[pastInvites.length - 1]['start']; 
     }


### PR DESCRIPTION
Bug fix: homepage display of reservations and invites when they are empty
The pages will gracefully handle empty lists.